### PR TITLE
Add SpawnList to Servers List

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,4 @@ Server lists, useful to promote your server or discover new servers to play on.
 - [40ServidoresMC](http://40servidoresmc.es/)
 - [MinecraftServers](https://minecraftservers.org/)
 - [NameMC](https://namemc.com/)
+- [SpawnList](https://spawnlist.net/) — daily-randomized listing so every server gets fair exposure; Votifier supported


### PR DESCRIPTION
SpawnList (https://spawnlist.net) is a Minecraft server directory with a daily-randomized listing order — every server gets fair exposure regardless of vote count. Votifier is supported for server-side vote rewards, but ranking is not vote-driven.

Adds it to the existing Servers List section.