### PR TITLE
Add SpawnList to Server Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,7 @@ Server lists are useful for discovery and marketing, but they vary heavily in qu
 - [TopG](https://topg.org/minecraft-servers/) — Server list covering multiple games.
 - [Planet Minecraft Servers](https://www.planetminecraft.com/servers/) — Community server listings.
 - [Servers-Minecraft](https://servers-minecraft.net/) — Server listing platform.
+- [SpawnList](https://spawnlist.net/) — Daily-randomized server directory; every server gets fair exposure regardless of vote count. Votifier supported.
 
 ---
 


### PR DESCRIPTION
SpawnList (https://spawnlist.net) is a Minecraft server directory with a daily-randomized listing — every server gets fair exposure regardless of vote count or payment. Votifier is supported for server-side vote rewards, but ranking is not vote-driven.

Adds it to the existing Server Lists section.

Note: a previous PR (#6) was submitted and a commenter noted the server ping check wasn't working. That bug has since been fixed — the handshake now uses proper VarInt string length encoding and reads the full packet-length-prefixed response. Hypixel and all large servers now ping correctly.